### PR TITLE
Typo Correction in RSpec

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,13 +34,13 @@
         <span>PHARRELLWILLIAMS.COM</span>
 
         <!-- display the images hosted on [https://s3.amazonaws.com/learn-verified/columbia-logo.png] -->
-        <img src="https://s3.amazonaws.com/learn-verified/columbia-logo.png"
+        <img src='https://s3.amazonaws.com/learn-verified/columbia-logo.png'>
         <!-- span text 'COLUMBIARECORDS.COM' -->
         <span>COLUMBIARECORDS.COM</span>
         <br>
 
         <!-- display the images hosted on [https://s3.amazonaws.com/learn-verified/sony-logo.png] -->
-        <img src="/images/sony-logo.png" alt="sony-logo">
+        <img src="https://s3.amazonaws.com/learn-verified/sony-logo.png">
       </div>
     </div>
   </body>

--- a/index.html
+++ b/index.html
@@ -11,34 +11,36 @@
         <div id="title-box">
 
           <!-- Level 4 'PHARRELL WILLIAMS' Header -->
-
+          <h4>PHARRELL WILLIAMS</h4>
           <!-- Level 2 'HAPPY' Header -->
-
+          <h2>HAPPY</h2>
           <!-- Level 4 '| FROM DESPICABLE ME...' Header -->
-
+          <h4>| FROM DESPICABLE ME 2 |</h4>
         </div>
       </div>
 
       <div id="back" class="album">
 
         <!-- Level 3 '| FROM DESPICABLE ME...' Header -->
-
+        <h3>| &nbsp;&nbsp; FROM DESPICABLE ME 2 &nbsp;&nbsp; |</h3>
         <!-- Level 1 'HAPPY' Header -->
-
+        <h1>HAPPY</h1>
         <!-- Level 3 'WRITTEN BY...' Header -->
+        <h3>WRITTEN BY PHARRELL WILLIAMS</h3>
 
         <!-- pararaph text 'PUBLISHED BY...' -->
-
+        <p> PUBLISHED BY EMI APRIL MUSIC, INC. OBO ITSELF AND MORE WATERFROM NAZARETH (ASCAP) / UNIVERSAL PICTURES MUSIC (ASCAP) | BACKGROUND VOCALS PERFORMED BY RHEA DUMMETT, TREVON HENDERSON, ASHLEY L. LEE, SHAMIKA HIGHTOWER, JASMINE MURRAY AND TERRENCE ROLLE | PRODUCED BY PHARRELL WILLIAMS | RECORDED BY MIKE LARSON FOR I AM OTHER ENTERTAINMENT AT CIRCLE HOUSE STUDIOS, MIAMI, FL | ASSISTED BY MATTHEW DESRAMEAUX | DIGITAL EDITING AND ARRANGEMENT BY ANDREW COLEMAN AND MIKE LARSON FOR I AM OTHER ENTERTAINMENT | MIXED BY LESLIE BRATHWAITE AT MUSIC BOX STUDIOS, ATLANTA, GA.</p>
         <!-- span text 'PHARRELLWILLIAMS.COM' -->
+        <span>PHARRELLWILLIAMS.COM</span>
 
         <!-- display the images hosted on [https://s3.amazonaws.com/learn-verified/columbia-logo.png] -->
-
+        <img src="https://s3.amazonaws.com/learn-verified/columbia-logo.png"
         <!-- span text 'COLUMBIARECORDS.COM' -->
-
+        <span>COLUMBIARECORDS.COM</span>
         <br>
 
         <!-- display the images hosted on [https://s3.amazonaws.com/learn-verified/sony-logo.png] -->
-
+        <img src="/images/sony-logo.png" alt="sony-logo">
       </div>
     </div>
   </body>

--- a/spec/album_cover_spec.rb
+++ b/spec/album_cover_spec.rb
@@ -38,7 +38,9 @@ RSpec.describe 'HTML Album Cover' do
 
         expect(back_cover.children.select {|ch| ch.name == "span"}[1].children.first.text).to include("COLUMBIARECORDS.COM"), "The second span tag should include the text 'COLUMBIARECORDS.COM'"
 
-        expect(back_cover.children.select {|ch| ch.name == "img"}[1].attributes["src"].value).to be == 'https://s3.amazonaws.com/learn-verified/sony-logo.png', "First image should have its source set to 'https://s3.amazonaws.com/learn-verified/columbia-logo.png'"
+        # Original SPEC Expect line has typo. Should have corrected description to make troubleshoot easier
+        # expect(back_cover.children.select {|ch| ch.name == "img"}[1].attributes["src"].value).to be == 'https://s3.amazonaws.com/learn-verified/sony-logo.png', "First image should have its source set to 'https://s3.amazonaws.com/learn-verified/columbia-logo.png'"
+        expect(back_cover.children.select {|ch| ch.name == "img"}[1].attributes["src"].value).to be == 'https://s3.amazonaws.com/learn-verified/sony-logo.png', "First image should have its source set to 'https://s3.amazonaws.com/learn-verified/sony-logo.png'"
 
       end
 

--- a/spec/album_cover_spec.rb
+++ b/spec/album_cover_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe 'HTML Album Cover' do
         expect(back_cover.children.select {|ch| ch.name == "span"}[1].children.first.text).to include("COLUMBIARECORDS.COM"), "The second span tag should include the text 'COLUMBIARECORDS.COM'"
 
         expect(back_cover.children.select {|ch| ch.name == "img"}[1].attributes["src"].value).to be == 'https://s3.amazonaws.com/learn-verified/sony-logo.png', "First image should have its source set to 'https://s3.amazonaws.com/learn-verified/columbia-logo.png'"
-        binding.pry
 
       end
 

--- a/spec/album_cover_spec.rb
+++ b/spec/album_cover_spec.rb
@@ -33,8 +33,9 @@ RSpec.describe 'HTML Album Cover' do
         expect(back_cover.children.select {|ch| ch.name == "span"}.first.children.first.text).to include("PHARRELLWILLIAMS.COM"), "The first span tag should include the text 'PHARRELLWILLIAMS.COM'"
 
         expect(back_cover.children.any? {|ch| ch.name == "img"}).to be == true, "No 'img' tag was found"
-        # binding.pry
+
         expect(back_cover.children.select {|ch| ch.name == "img"}[0].attributes["src"].value).to be == 'https://s3.amazonaws.com/learn-verified/columbia-logo.png', "First image should have its source set to 'https://s3.amazonaws.com/learn-verified/columbia-logo.png'"
+
         expect(back_cover.children.select {|ch| ch.name == "span"}[1].children.first.text).to include("COLUMBIARECORDS.COM"), "The second span tag should include the text 'COLUMBIARECORDS.COM'"
 
         expect(back_cover.children.select {|ch| ch.name == "img"}[1].attributes["src"].value).to be == 'https://s3.amazonaws.com/learn-verified/sony-logo.png', "First image should have its source set to 'https://s3.amazonaws.com/learn-verified/columbia-logo.png'"

--- a/spec/album_cover_spec.rb
+++ b/spec/album_cover_spec.rb
@@ -33,12 +33,12 @@ RSpec.describe 'HTML Album Cover' do
         expect(back_cover.children.select {|ch| ch.name == "span"}.first.children.first.text).to include("PHARRELLWILLIAMS.COM"), "The first span tag should include the text 'PHARRELLWILLIAMS.COM'"
 
         expect(back_cover.children.any? {|ch| ch.name == "img"}).to be == true, "No 'img' tag was found"
-
+        # binding.pry
         expect(back_cover.children.select {|ch| ch.name == "img"}[0].attributes["src"].value).to be == 'https://s3.amazonaws.com/learn-verified/columbia-logo.png', "First image should have its source set to 'https://s3.amazonaws.com/learn-verified/columbia-logo.png'"
-
         expect(back_cover.children.select {|ch| ch.name == "span"}[1].children.first.text).to include("COLUMBIARECORDS.COM"), "The second span tag should include the text 'COLUMBIARECORDS.COM'"
 
         expect(back_cover.children.select {|ch| ch.name == "img"}[1].attributes["src"].value).to be == 'https://s3.amazonaws.com/learn-verified/sony-logo.png', "First image should have its source set to 'https://s3.amazonaws.com/learn-verified/columbia-logo.png'"
+        binding.pry
 
       end
 


### PR DESCRIPTION
Line #41 in "spec/album_cover_spec.rb" should have description update from "columbia-logo.png" to "sony-logo.png"

If this requires more accurate description, please let me know to improve my future Pull Requests